### PR TITLE
PR: Enhancements for News Editor

### DIFF
--- a/www/inc/config.php
+++ b/www/inc/config.php
@@ -394,10 +394,10 @@
 	define('NEWS_ARTICLE_LIMIT', 65536);
 
 	// Allowed news abstract tags to use in strip_tags
-	define('ALLOWED_ABSTRACT_TAGS', '<font><img><a><span><s><big><strong><em><u>');
+	define('ALLOWED_ABSTRACT_TAGS', '<a><em><font><img><s><span><strong><u>');
 
 	// Allowed news article tags to use in strip_tags
-	define('ALLOWED_ARTICLE_TAGS', '<h1><h2><h3><h4><h5><h6><font><img><li><ul><ol><br><a><td><tr><table><span><s><big><strong><em><u><p>');
+	define('ALLOWED_ARTICLE_TAGS', '<a><br><em><font><h1><h2><h3><h4><h5><h6><img><li><ol><p><s><span><strong><table><td><th><tr><u><ul>');
 	
 	// When to archive news articles by default
 	define('DEFAULT_NEWS_ARCHIVE_TIME', 86400 * 7);

--- a/www/tmpl/adm/adm_news.php
+++ b/www/tmpl/adm/adm_news.php
@@ -67,7 +67,7 @@ Need to define which fields allow HTML tags and which are plain-text only, eithe
 	<hr />
 <?php } ?>
 <div class="docs_text">
-	<strong>Warning:</strong> "Previewing" will preserve your article but <em><u>not</u></em> publish it.
+	<strong>Warning:</strong> "Preview" will preserve your article but <em><u>not</u></em> publish it.
 	If there is an error, your article will be lost. Please write it up using a separate tool and
 	paste the content in.
 </div>
@@ -115,7 +115,7 @@ Need to define which fields allow HTML tags and which are plain-text only, eithe
 				</td>
 			</tr>
 			<tr class="message">
-				<td class="message">Live&nbsp;Timestamp:</td>
+				<td class="message">Publish&nbsp;Timestamp:</td>
 				<td class="message" colspan="2"><input class="msg_form_input" type="text" name="live_date" maxlength="10" size="12" value="<?php echo $article['live']; ?>" /></td>
 			</tr>
 			<tr class="message">
@@ -123,7 +123,7 @@ Need to define which fields allow HTML tags and which are plain-text only, eithe
 				<td class="message" colspan="2"><input class="msg_form_input" type="text" name="archive_date" maxlength="10" size="12" value="<?php echo $article['archive']; ?>" /></td>
 			</tr>
 			<tr class="message">
-				<td class="message">Expiry&nbsp;Timestamp:</td>
+				<td class="message">Purge&nbsp;Timestamp:</td>
 				<td class="message" colspan="2"><input class="msg_form_input" type="text" name="expiration_date" maxlength="10" size="12" value="<?php echo $article['expiration']; ?>" /></td>
 			</tr>
 			<tr class="message">

--- a/www/tmpl/adm/adm_news.php
+++ b/www/tmpl/adm/adm_news.php
@@ -52,7 +52,6 @@
 ?>
 
 <!--
-Need to surface remaining char counter for headline.
 Need to define which fields allow HTML tags and which are plain-text only, either as notice above warning text or bracketed as part of <th> text.
 -->
 
@@ -75,8 +74,14 @@ Need to define which fields allow HTML tags and which are plain-text only, eithe
 	<form action="handler.php" method="post">
 		<table class="message" role="presentation">
 			<tr class="message">
+				<td class="message">&nbsp;</td>
+				<td class="message align_right">
+					<span class="characters_left" id="headline_characters_left">&nbsp;</span>
+				</td>
+			</tr>
+			<tr class="message">
 				<td class="message">Headline:</td>
-				<td class="message"><input class="msg_form_input" type="text" name="headline" maxlength="<?php echo NEWS_HEADLINE_LIMIT; ?>" value="<?php echo $article['headline']; ?>" size="50" /></td>
+				<td class="message"><input class="msg_form_input" id="msg_headline" type="text" name="headline" maxlength="<?php echo NEWS_HEADLINE_LIMIT; ?>" value="<?php echo $article['headline']; ?>" size="58" /></td>
 				<td class="message align_right">
 					<span class="characters_left" id="abstract_characters_left">&nbsp;</span>
 				</td>
@@ -131,9 +136,9 @@ Need to define which fields allow HTML tags and which are plain-text only, eithe
 				<td class="message" colspan="2">
 					<script type="text/javascript">
 						drawButton('preview', 'preview', 'validate_preview()');
-						register_textarea_length_handlers('msg_article', 'article_characters_left', <?php echo NEWS_ARTICLE_LIMIT; ?>);
+						register_textarea_length_handlers('msg_headline', 'headline_characters_left', <?php echo NEWS_HEADLINE_LIMIT; ?>);
 						register_textarea_length_handlers('msg_abstract', 'abstract_characters_left', <?php echo NEWS_ABSTRACT_LIMIT; ?>);
-						
+						register_textarea_length_handlers('msg_article', 'article_characters_left', <?php echo NEWS_ARTICLE_LIMIT; ?>);
 					</script>
 					&nbsp;
 					<script type="text/javascript">
@@ -141,8 +146,6 @@ Need to define which fields allow HTML tags and which are plain-text only, eithe
 					</script>
 				</td>
 			</tr>
-
-			
 		</table>
 		<input type="hidden" name="task" value="news" />
 		<input type="hidden" name="subtask" value="submit" />

--- a/www/tmpl/adm/adm_news.php
+++ b/www/tmpl/adm/adm_news.php
@@ -31,9 +31,9 @@
 	include_once('inc/news.php');
 
 	$preview = isset($_REQUEST['task']) && $_REQUEST['task'] == 'preview';
-	$article['headline'] = '';
-	$article['abstract'] = '';
-	$article['article'] = '';
+	$article['headline'] = 'Alphanumeric and space only';
+	$article['abstract'] = 'Allowed HTML tags: a, em, font, img, s, span, strong, u';
+	$article['article'] = 'Allowed HTML tags: a, br, em, font, h1 to h6, img, li, ol, p, s, span, strong, table, td, th, tr, u, ul';
 	$article['author'] = 0;
 	$article['live'] = PAGE_START_TIME;
 	$article['archive'] = PAGE_START_TIME + DEFAULT_NEWS_ARCHIVE_TIME;
@@ -50,10 +50,6 @@
 	}
 
 ?>
-
-<!--
-Need to define which fields allow HTML tags and which are plain-text only, either as notice above warning text or bracketed as part of <th> text.
--->
 
 <div class="header2">News Desk</div>
 <?php if ($preview) { ?>


### PR DESCRIPTION
Fixes #15

- Re-worded "Live Timestamp" to "Publish Timestamp" to reflect article being published
- Re-worded "Expiry Timestamp" to "Purge Timestamp" to reflect article deletion
- Added and aligned remaining characters counter for headline
- Surfaced allowed HTML tags for abstract and article input fields instead of having to dig through code to see what's allowed. This will allow users with access permissions to news editor, but no access to the code base to know which HTML tags can be used.
- Headline field is alpha-numeric and space only
- Removed `<big>` and added `<th>` for allowed tags
- Re-ordered allowed tags alphabetically