### PR TITLE
Corrected previous fix for alliance rejection

### DIFF
--- a/www/hndl/sub/alliance_reject.php
+++ b/www/hndl/sub/alliance_reject.php
@@ -22,6 +22,7 @@
  */
 
 	include_once('hndl/common.php');
+	include_once('inc/alliance.php');
 
 	$return_vars['page'] = 'main';
 	
@@ -33,7 +34,7 @@
 			break;
 		}
 		
-		if (!ALLIANCE_LEADER) {
+		if (!defined('ALLIANCE_LEADER') || !ALLIANCE_LEADER) {
 			$return_codes[] = 1086;
 			break;
 		}


### PR DESCRIPTION
Previous fix would take a referenced assumption for ALLIANCE_LEADER as it was not included. This fix gives it a definite reference by linking it to the core page where the constant was defined. Inclusion might have been left out due to previous oversight.